### PR TITLE
Layered link highlights with continuous drift animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,38 +28,52 @@
 
       <nav class="link-grid" aria-label="Profile Links">
         <a id="faceit" class="link brand-faceit" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/faceit.svg" alt="" aria-hidden="true" />
-          <span>FaceIT</span>
+          <span class="card-inner">
+            <img class="icon" src="assets/icons/faceit.svg" alt="" aria-hidden="true" />
+            <span>FaceIT</span>
+          </span>
         </a>
 
         <a id="leetify" class="link brand-leetify" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/leetify.svg" alt="" aria-hidden="true" />
-          <span>Leetify</span>
+          <span class="card-inner">
+            <img class="icon" src="assets/icons/leetify.svg" alt="" aria-hidden="true" />
+            <span>Leetify</span>
+          </span>
         </a>
 
         <a id="deadlock" class="link brand-deadlock" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/deadlock.svg" alt="" aria-hidden="true" />
-          <span>Deadlock</span>
+          <span class="card-inner">
+            <img class="icon" src="assets/icons/deadlock.svg" alt="" aria-hidden="true" />
+            <span>Deadlock</span>
+          </span>
         </a>
 
         <a id="valorant" class="link brand-valorant" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/valorant.svg" alt="" aria-hidden="true" />
-          <span>Valorant</span>
+          <span class="card-inner">
+            <img class="icon" src="assets/icons/valorant.svg" alt="" aria-hidden="true" />
+            <span>Valorant</span>
+          </span>
         </a>
 
         <a id="overwatch" class="link brand-overwatch" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/overwatch.svg" alt="" aria-hidden="true" />
-          <span>Overwatch</span>
+          <span class="card-inner">
+            <img class="icon" src="assets/icons/overwatch.svg" alt="" aria-hidden="true" />
+            <span>Overwatch</span>
+          </span>
         </a>
 
         <a id="marvel" class="link brand-marvel" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/marvel-rivals.svg" alt="" aria-hidden="true" />
-          <span>Marvel Rivals</span>
+          <span class="card-inner">
+            <img class="icon" src="assets/icons/marvel-rivals.svg" alt="" aria-hidden="true" />
+            <span>Marvel Rivals</span>
+          </span>
         </a>
 
         <a id="youtube" class="link brand-youtube" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/youtube.svg" alt="" aria-hidden="true" />
-          <span>YouTube</span>
+          <span class="card-inner">
+            <img class="icon" src="assets/icons/youtube.svg" alt="" aria-hidden="true" />
+            <span>YouTube</span>
+          </span>
         </a>
       </nav>
     </main>

--- a/script.js
+++ b/script.js
@@ -74,3 +74,20 @@ window.LINKS = {
     el.addEventListener('touchend', reset, {passive:true});
   });
 })();
+
+// Slow drifting highlight
+(function highlightDrift(){
+  const links = document.querySelectorAll('.link');
+  let t = 0;
+
+  function frame(){
+    t += 0.5;
+    links.forEach((el, i) => {
+      const x = ((t + i * 40) % 260) - 130;
+      el.style.setProperty('--shine', x + '%');
+    });
+    requestAnimationFrame(frame);
+  }
+
+  requestAnimationFrame(frame);
+})();

--- a/style.css
+++ b/style.css
@@ -145,14 +145,15 @@ body {
 .link {
   --tiltX: 0deg; --tiltY: 0deg;
   position: relative;
-  display: grid; grid-auto-flow: column; align-items: center; justify-content: center; gap: 8px;
+  display: grid; align-items: center; justify-content: center;
   text-decoration: none;
   color: var(--text);
   padding: 12px 14px;
   border-radius: 14px;
   background: var(--glass);
   border: 1px solid var(--border);
-  backdrop-filter: saturate(160%) blur(10px);
+  backdrop-filter: blur(20px) saturate(180%);
+  overflow: hidden;
   font-weight: 800; letter-spacing: .3px;
   text-transform: none;
   box-shadow: 0 8px 18px var(--shadow);
@@ -178,6 +179,16 @@ body {
 
 .icon { width: 18px; height: 18px; display: block; filter: drop-shadow(0 1px 0 rgba(0,0,0,.25)); }
 
+.card-inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
 /* animated accent ring */
 .link::after {
   content: "";
@@ -187,17 +198,19 @@ body {
   -webkit-mask: linear-gradient(#000 0 0) padding-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor; mask-composite: exclude;
   opacity: .6;
+  z-index: 3;
 }
 
-/* subtle moving highlight on hover */
+/* moving highlight */
 .link::before {
   content: "";
   position: absolute; inset: 0; border-radius: inherit;
-  background: linear-gradient(120deg, transparent 0%, rgba(255,255,255,.06) 50%, transparent 100%);
-  transform: translateX(-130%);
-  transition: transform .6s ease;
+  background: linear-gradient(120deg, transparent 0%, rgba(255,255,255,.25) 50%, transparent 100%);
+  mix-blend-mode: screen;
+  transform: translateX(var(--shine, -130%));
+  pointer-events: none;
+  z-index: 2;
 }
-.link:hover::before { transform: translateX(130%); }
 
 /* Brand accents */
 .brand-faceit    { --accent: var(--faceit); }


### PR DESCRIPTION
## Summary
- Wrap link contents in a new `<span class="card-inner">` for layered effects
- Add blurred, saturated backdrop with moving screen-blend highlight
- Animate highlight drift across cards via `requestAnimationFrame`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e98d6f108320ad57f5dcef16870d