### PR TITLE
Replace CSS background with WebGL canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="bg" aria-hidden="true"></div>
+      <canvas id="bgCanvas" class="bg"></canvas>
 
     <!-- floating theme toggle -->
     <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle theme">◎</button>

--- a/script.js
+++ b/script.js
@@ -41,6 +41,104 @@ window.LINKS = {
   });
 })();
 
+// WebGL background animation
+(function webglBG(){
+  const canvas = document.getElementById('bgCanvas');
+  const gl = canvas?.getContext('webgl');
+  if (!canvas || !gl) return;
+
+  const vertSrc = `
+    attribute vec2 position;
+    void main(){
+      gl_Position = vec4(position, 0.0, 1.0);
+    }
+  `;
+  const fragSrc = `
+    precision mediump float;
+    uniform vec2 u_res;
+    uniform float u_time;
+    uniform vec3 u_color1;
+    uniform vec3 u_color2;
+    float hash(vec2 p){ return fract(sin(dot(p, vec2(127.1,311.7))) * 43758.5453123); }
+    float noise(vec2 p){
+      vec2 i = floor(p);
+      vec2 f = fract(p);
+      float a = hash(i);
+      float b = hash(i + vec2(1.0,0.0));
+      float c = hash(i + vec2(0.0,1.0));
+      float d = hash(i + vec2(1.0,1.0));
+      vec2 u = f*f*(3.0-2.0*f);
+      return mix(a,b,u.x) + (c-a)*u.y*(1.0-u.x) + (d-b)*u.x*u.y;
+    }
+    void main(){
+      vec2 uv = gl_FragCoord.xy / u_res.xy;
+      float n = noise(uv*3.0 + u_time*0.05);
+      vec3 col = mix(u_color1, u_color2, n);
+      gl_FragColor = vec4(col, 1.0);
+    }
+  `;
+
+  function compile(type, src){
+    const sh = gl.createShader(type);
+    gl.shaderSource(sh, src);
+    gl.compileShader(sh);
+    return sh;
+  }
+
+  const vs = compile(gl.VERTEX_SHADER, vertSrc);
+  const fs = compile(gl.FRAGMENT_SHADER, fragSrc);
+  const prog = gl.createProgram();
+  gl.attachShader(prog, vs);
+  gl.attachShader(prog, fs);
+  gl.linkProgram(prog);
+  gl.useProgram(prog);
+
+  const posLoc = gl.getAttribLocation(prog, 'position');
+  const timeLoc = gl.getUniformLocation(prog, 'u_time');
+  const resLoc = gl.getUniformLocation(prog, 'u_res');
+  const color1Loc = gl.getUniformLocation(prog, 'u_color1');
+  const color2Loc = gl.getUniformLocation(prog, 'u_color2');
+
+  const buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+    -1,-1, 1,-1, -1,1,
+    -1,1, 1,-1, 1,1
+  ]), gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(posLoc);
+  gl.vertexAttribPointer(posLoc,2,gl.FLOAT,false,0,0);
+
+  function resize(){
+    canvas.width = innerWidth;
+    canvas.height = innerHeight;
+    gl.viewport(0,0,canvas.width,canvas.height);
+  }
+  window.addEventListener('resize', resize);
+  resize();
+
+  const mq = window.matchMedia('(prefers-color-scheme: dark)');
+  const root = document.documentElement;
+  function setPalette(){
+    const dark = [[96/255,165/255,250/255],[167/255,139/255,250/255]];
+    const light = [[224/255,242/255,254/255],[237/255,233/255,254/255]];
+    const isDark = root.getAttribute('data-theme') === 'dark' || (root.getAttribute('data-theme') !== 'light' && mq.matches);
+    const palette = isDark ? dark : light;
+    gl.uniform3fv(color1Loc, palette[0]);
+    gl.uniform3fv(color2Loc, palette[1]);
+  }
+  mq.addEventListener('change', setPalette);
+  new MutationObserver(setPalette).observe(root, {attributes:true, attributeFilter:['data-theme']});
+  setPalette();
+
+  function render(t){
+    gl.uniform1f(timeLoc, t*0.001);
+    gl.uniform2f(resLoc, canvas.width, canvas.height);
+    gl.drawArrays(gl.TRIANGLES,0,6);
+    requestAnimationFrame(render);
+  }
+  requestAnimationFrame(render);
+})();
+
 // Subtle 3D tilt on hover
 (function tilt(){
   const links = document.querySelectorAll('.link');

--- a/style.css
+++ b/style.css
@@ -43,39 +43,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Animated ambient background */
+/* WebGL background canvas */
 .bg {
   position: fixed;
-  inset: -40vmax;
+  inset: 0;
   z-index: -1;
   filter: blur(40px) saturate(130%);
-  background:
-    radial-gradient(40vmax 30vmax at 10% -10%, rgba(96,165,250,0.18), transparent 60%),
-    radial-gradient(40vmax 30vmax at 110% 0%, rgba(167,139,250,0.16), transparent 60%),
-    conic-gradient(from var(--angle, 0deg) at 50% 50%,
-      rgba(255,255,255,0.0), rgba(96,165,250,0.10), rgba(167,139,250,0.10), rgba(255,255,255,0.0) 75%);
-  animation: spin 32s linear infinite;
-}
-.bg::before,
-.bg::after {
-  content: "";
-  position: absolute;
-  width: 60vmin; height: 60vmin;
-  background: radial-gradient(closest-side, rgba(167,139,250,.22), transparent);
-  border-radius: 50%;
-  filter: blur(12px);
-  animation: drift 18s ease-in-out infinite alternate;
-}
-.bg::after {
-  width: 40vmin; height: 40vmin;
-  background: radial-gradient(closest-side, rgba(96,165,250,.22), transparent);
-  animation-duration: 22s;
-  animation-delay: -6s;
-}
-@keyframes spin { to { --angle: 360deg; } }
-@keyframes drift {
-  0%   { transform: translate(-10%, -8%) scale(1);   }
-  100% { transform: translate(12%, 10%)  scale(1.08); }
 }
 
 .shell {
@@ -210,8 +183,6 @@ body {
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .bg { animation: none; }
-  .bg::before, .bg::after { animation: none; }
   .brand { animation: none; }
   .brand::after { animation: none; }
   .link { animation: none; }


### PR DESCRIPTION
## Summary
- Swap animated background div for canvas element
- Render shader-based noise with WebGL and react to color scheme changes
- Remove old CSS background animations keeping blur positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e98e4ba483209f40eeebbab70a3c