### PR TITLE
Apply permanent dark theme and widen link buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>HoppCX</title>
-    <meta name="theme-color" content="#0b0f1a" />
-    <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#05070d" />
+    <meta name="color-scheme" content="dark" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -18,12 +18,9 @@
   <body>
       <canvas id="bgCanvas" class="bg"></canvas>
 
-    <!-- floating theme toggle -->
-    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle theme">◎</button>
-
     <main class="shell">
       <section class="hero">
-        <h1 class="brand" aria-label="HoppCX">HoppCX</h1>
+        <h1 class="brand" aria-label="HoppCX - Links">HoppCX - Links</h1>
       </section>
 
       <nav class="link-grid" aria-label="Profile Links">
@@ -65,6 +62,6 @@
     </main>
 
     <script src="script.js" defer></script>
-    <noscript>Enable JavaScript to use theme toggle and animations.</noscript>
+    <noscript>Enable JavaScript to use animations.</noscript>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -19,28 +19,6 @@ window.LINKS = {
   });
 })();
 
-// Theme toggle with persistence
-(function themeToggle(){
-  const root = document.documentElement;
-  const btn = document.getElementById('themeToggle');
-  const metaTheme = document.querySelector('meta[name="theme-color"]');
-
-  const setTheme = (mode) => {
-    const isLight = mode === 'light';
-    root.setAttribute('data-theme', isLight ? 'light' : 'dark');
-    localStorage.setItem('theme', isLight ? 'light' : 'dark');
-    if (metaTheme) metaTheme.content = isLight ? '#f6f7fb' : '#0b0f1a';
-  };
-
-  const saved = localStorage.getItem('theme');
-  if (saved === 'light' || saved === 'dark') setTheme(saved);
-
-  btn?.addEventListener('click', () => {
-    const next = (root.getAttribute('data-theme') === 'light') ? 'dark' : 'light';
-    setTheme(next);
-  });
-})();
-
 // WebGL background animation
 (function webglBG(){
   const canvas = document.getElementById('bgCanvas');
@@ -116,19 +94,9 @@ window.LINKS = {
   window.addEventListener('resize', resize);
   resize();
 
-  const mq = window.matchMedia('(prefers-color-scheme: dark)');
-  const root = document.documentElement;
-  function setPalette(){
-    const dark = [[96/255,165/255,250/255],[167/255,139/255,250/255]];
-    const light = [[224/255,242/255,254/255],[237/255,233/255,254/255]];
-    const isDark = root.getAttribute('data-theme') === 'dark' || (root.getAttribute('data-theme') !== 'light' && mq.matches);
-    const palette = isDark ? dark : light;
-    gl.uniform3fv(color1Loc, palette[0]);
-    gl.uniform3fv(color2Loc, palette[1]);
-  }
-  mq.addEventListener('change', setPalette);
-  new MutationObserver(setPalette).observe(root, {attributes:true, attributeFilter:['data-theme']});
-  setPalette();
+  const palette = [[96/255,165/255,250/255],[167/255,139/255,250/255]];
+  gl.uniform3fv(color1Loc, palette[0]);
+  gl.uniform3fv(color2Loc, palette[1]);
 
   function render(t){
     gl.uniform1f(timeLoc, t*0.001);

--- a/style.css
+++ b/style.css
@@ -1,14 +1,13 @@
 :root {
-  --bg: #0b0f1a;
-  --text: #e5e7eb;
-  --muted: #9ca3af;
-  --glass: rgba(255,255,255,0.05);
-  --border: rgba(255,255,255,0.12);
+  --bg: #05070d;
+  --text: #d1d5db;
+  --muted: #6b7280;
+  --glass: rgba(255,255,255,0.04);
+  --border: rgba(255,255,255,0.1);
   --outline: rgba(96,165,250,.45);
-  --shadow: rgba(0,0,0,.35);
+  --shadow: rgba(0,0,0,.5);
 
-  --brand-grad: linear-gradient(90deg,#60a5fa, #a78bfa, #60a5fa);
-  --brand-sheen: linear-gradient(120deg, transparent 0%, rgba(255,255,255,.25) 20%, transparent 40%);
+  --brand-color: #e5e7eb;
 
   --faceit: #ff5500;
   --leetify: #00e5c0;
@@ -24,18 +23,6 @@
 
   --font-brand: "Manrope", system-ui, sans-serif;
   --font-ui: "Manrope", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial;
-}
-
-:root[data-theme="light"] {
-  --bg: #f6f7fb;
-  --text: #0f172a;
-  --muted: #475569;
-  --glass: rgba(0,0,0,0.03);
-  --border: rgba(0,0,0,0.10);
-  --outline: rgba(59,130,246,.55);
-  --shadow: rgba(0,0,0,.15);
-  --wght-base: 600;
-  --wdth-base: 105;
 }
 
 * { box-sizing: border-box; }
@@ -72,16 +59,10 @@ body {
 .brand {
   margin: 0;
   font-family: var(--font-brand);
-  font-size: clamp(48px, 9vw, 88px);
+  font-size: clamp(36px, 6vw, 56px);
   letter-spacing: .6px;
-  line-height: .9;
-  background: var(--brand-grad);
-  background-size: 200% 100%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: hue 14s linear infinite;
-  position: relative;
+  line-height: 1;
+  color: var(--brand-color);
   font-weight: var(--wght);
   font-variation-settings: "wght" var(--wght), "wdth" var(--wdth);
   transition: font-variation-settings .6s ease;
@@ -90,43 +71,15 @@ body {
   --wght: calc(var(--wght-base) + 100);
   --wdth: calc(var(--wdth-base) + 10);
 }
-.brand::after { /* subtle sheen that sweeps across the text */
-  content: "";
-  position: absolute; inset: 0;
-  background: var(--brand-sheen);
-  background-size: 300% 100%;
-  mix-blend-mode: screen;
-  animation: sheen 3.5s ease-in-out infinite;
-  pointer-events: none;
-}
-@keyframes hue { 0% { background-position: 0% 50%; } 100% { background-position: 100% 50%; } }
-@keyframes sheen { 0% { background-position: -120% 0; } 100% { background-position: 180% 0; } }
-
-/* Theme toggle fixed top-right */
-.theme-toggle {
-  position: fixed;
-  top: 14px; right: 14px;
-  z-index: 10;
-  border: 1px solid var(--border);
-  background: var(--glass);
-  color: var(--text);
-  border-radius: 999px;
-  width: 42px; height: 42px;
-  display: grid; place-items: center;
-  cursor: pointer;
-  backdrop-filter: saturate(160%) blur(10px);
-  transition: transform .15s ease, border-color .2s ease;
-}
-.theme-toggle:hover { transform: translateY(-1px); border-color: rgba(255,255,255,0.28); }
-.theme-toggle:focus-visible { outline: 2px solid var(--outline); outline-offset: 3px; }
 
 /* Compact link buttons in a responsive grid */
 .link-grid {
   width: 100%;
-  max-width: 420px;
+  max-width: 600px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   gap: 14px;
   perspective: 800px;
 }
@@ -136,7 +89,7 @@ body {
   display: grid; grid-auto-flow: column; align-items: center; justify-content: center; gap: 8px;
   text-decoration: none;
   color: var(--text);
-  padding: 12px 14px;
+  padding: 14px 20px;
   border-radius: 14px;
   background: transparent;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Set site to a fixed dark palette and remove theme toggle
- Replace bright "HoppCX" hero with sleek "HoppCX - Links"
- Widen link buttons and stack them vertically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f225ba148320aa29fac26d1f3e31