### PR TITLE
Use Nabla font for site branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Nabla&display=swap" rel="stylesheet">
 
     <link rel="preload" href="assets/icons/faceit.svg" as="image" type="image/svg+xml" />
     <link rel="stylesheet" href="style.css" />

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@
     --wdth-base: 100;
     --wght: var(--wght-base);
     --wdth: var(--wdth-base);
-    --font-brand: "Manrope", system-ui, sans-serif;
+    --font-brand: "Nabla", "Manrope", system-ui, sans-serif;
     --font-ui: "Manrope", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial;
 }
 


### PR DESCRIPTION
## Summary
- Load Nabla from Google Fonts
- Apply Nabla font to HoppCX heading via CSS

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b520fe66988320828dc25b86394945