### PR TITLE
Compute scaled width and height for layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,7 +25,12 @@ window.addEventListener("DOMContentLoaded", () => {
   const BASE = { w: 1920, h: 1080 };
   function updateScale(){
     const s = Math.min(window.innerWidth/BASE.w, window.innerHeight/BASE.h);
-    document.documentElement.style.setProperty('--site-scale', String(s));
+    const w = BASE.w * s;
+    const h = BASE.h * s;
+    const root = document.documentElement.style;
+    root.setProperty('--site-scale', String(s));
+    root.setProperty('--site-width', `${w}px`);
+    root.setProperty('--site-height', `${h}px`);
   }
   window.addEventListener('resize', updateScale);
   updateScale();

--- a/style.css
+++ b/style.css
@@ -21,6 +21,8 @@
   --font-brand: "Nabla", "Manrope", system-ui, sans-serif;
   --font-ui: "Manrope", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial;
   --site-scale: 1;
+  --site-width: 100vw;
+  --site-height: 100dvh;
 }
 
 * { box-sizing: border-box; }
@@ -43,7 +45,8 @@ body {
 .bg.smoke { z-index: 1; pointer-events: none; filter: none; }
 
 .shell {
-  min-height: 100dvh;
+  width: var(--site-width);
+  height: var(--site-height);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -52,8 +55,7 @@ body {
   gap: 24px;
   position: relative;
   z-index: 2;
-  transform: scale(var(--site-scale));
-  transform-origin: top center;
+  margin: 0 auto;
 }
 
 canvas { display: block; width: 100%; height: 100%; }


### PR DESCRIPTION
## Summary
- compute `--site-width` and `--site-height` along with `--site-scale`
- size `.shell` using the new CSS variables instead of transform scaling

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b607f7a6dc8320bdef0a7d117436a9