### PR TITLE
Use transform-based scaling for viewport

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,13 +24,11 @@ window.addEventListener("DOMContentLoaded", () => {
   // Site scale for consistent framing when zooming
   const BASE = { w: 1920, h: 1080 };
   function updateScale(){
-    const s = Math.min(window.innerWidth/BASE.w, window.innerHeight/BASE.h);
-    const w = BASE.w * s;
-    const h = BASE.h * s;
-    const root = document.documentElement.style;
-    root.setProperty('--site-scale', String(s));
-    root.setProperty('--site-width', `${w}px`);
-    root.setProperty('--site-height', `${h}px`);
+    const s = Math.min(
+      window.innerWidth / BASE.w,
+      window.innerHeight / BASE.h
+    );
+    document.documentElement.style.setProperty('--site-scale', String(s));
   }
   window.addEventListener('resize', updateScale);
   updateScale();

--- a/style.css
+++ b/style.css
@@ -56,6 +56,8 @@ body {
   position: relative;
   z-index: 2;
   margin: 0 auto;
+  transform: scale(var(--site-scale));
+  transform-origin: top left;
 }
 
 canvas { display: block; width: 100%; height: 100%; }


### PR DESCRIPTION
## Summary
- Update `updateScale` to control only `--site-scale`
- Scale the shell container with CSS transforms and top-left origin

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE'
const style = { setProperty: (k,v) => console.log('set', k, v) };
const BASE = { w: 1920, h: 1080 };
function updateScale(winW, winH){
  const s = Math.min(winW/BASE.w, winH/BASE.h);
  style.setProperty('--site-scale', String(s));
}
// simulate a call
updateScale(375, 667);
NODE`
- `node - <<'NODE'
const BASE = { w: 1920, h: 1080 };
function calcScale(w, h){
  return Math.min(w/BASE.w, h/BASE.h);
}
const devices = [
  {name: 'iPhone SE', w:375, h:667},
  {name: 'iPhone 12 Pro', w:390, h:844},
  {name: 'Pixel 5', w:393, h:851},
  {name: 'iPad Mini', w:768, h:1024}
];
devices.forEach(d => {
  console.log(`${d.name} (${d.w}x${d.h}) -> scale ${calcScale(d.w,d.h).toFixed(4)}`);
});
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b617fbc408832095dc89eba40ff797