### PR TITLE
Drop custom site scaling for responsive layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,18 +21,6 @@ window.addEventListener("DOMContentLoaded", () => {
     if (a) a.href = LINKS[id];
   }
 
-  // Site scale for consistent framing when zooming
-  const BASE = { w: 1920, h: 1080 };
-  function updateScale(){
-    const s = Math.min(
-      window.innerWidth / BASE.w,
-      window.innerHeight / BASE.h
-    );
-    document.documentElement.style.setProperty('--site-scale', String(s));
-  }
-  window.addEventListener('resize', updateScale);
-  updateScale();
-
   // WebGL bg
   initBG();
 

--- a/style.css
+++ b/style.css
@@ -20,9 +20,6 @@
   --wdth: var(--wdth-base);
   --font-brand: "Nabla", "Manrope", system-ui, sans-serif;
   --font-ui: "Manrope", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial;
-  --site-scale: 1;
-  --site-width: 100vw;
-  --site-height: 100dvh;
 }
 
 * { box-sizing: border-box; }
@@ -45,8 +42,8 @@ body {
 .bg.smoke { z-index: 1; pointer-events: none; filter: none; }
 
 .shell {
-  width: var(--site-width);
-  height: var(--site-height);
+  width: 100%;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -56,8 +53,7 @@ body {
   position: relative;
   z-index: 2;
   margin: 0 auto;
-  transform: scale(var(--site-scale));
-  transform-origin: top left;
+  max-width: 1920px;
 }
 
 canvas { display: block; width: 100%; height: 100%; }


### PR DESCRIPTION
## Summary
- Remove JavaScript `updateScale` logic and resize listener.
- Simplify `.shell` to a flex container with max-width and no transforms.
- Drop unused CSS variables related to scaling.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b61c79167083209d53d429999d1dfc