### PR TITLE
Add meta description and lazy-load images

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <title>hoppcx.top</title>
     <meta name="theme-color" content="#000000" />
     <meta name="color-scheme" content="dark" />
+    <meta name="description" content="Brief description of hoppcx.top">
+    <link rel="icon" href="assets/icons/faceit.svg" type="image/svg+xml">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -27,35 +29,35 @@
 
       <nav class="link-grid" aria-label="Profile Links">
         <a id="faceit" class="link brand-faceit" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/faceit.svg" alt="" aria-hidden="true" />
+          <img class="icon" src="assets/icons/faceit.svg" alt="" aria-hidden="true" loading="lazy" />
           <span>FaceIT</span>
         </a>
 
         <a id="leetify" class="link brand-leetify" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/leetify.svg" alt="" aria-hidden="true" />
+          <img class="icon" src="assets/icons/leetify.svg" alt="" aria-hidden="true" loading="lazy" />
           <span>Leetify</span>
         </a>
 
         <div class="game-grid">
           <a id="deadlock" class="link brand-deadlock" href="#" target="_blank" rel="noopener" aria-label="Deadlock">
-            <img class="icon game-icon" src="assets/icons/deadlock.svg" alt="" aria-hidden="true" />
+            <img class="icon game-icon" src="assets/icons/deadlock.svg" alt="" aria-hidden="true" loading="lazy" />
           </a>
 
           <a id="valorant" class="link brand-valorant" href="#" target="_blank" rel="noopener" aria-label="Valorant">
-            <img class="icon game-icon" src="assets/icons/valorant.svg" alt="" aria-hidden="true" />
+            <img class="icon game-icon" src="assets/icons/valorant.svg" alt="" aria-hidden="true" loading="lazy" />
           </a>
 
           <a id="overwatch" class="link brand-overwatch" href="#" target="_blank" rel="noopener" aria-label="Overwatch">
-            <img class="icon game-icon" src="assets/icons/overwatch.svg" alt="" aria-hidden="true" />
+            <img class="icon game-icon" src="assets/icons/overwatch.svg" alt="" aria-hidden="true" loading="lazy" />
           </a>
 
           <a id="marvel" class="link brand-marvel" href="#" target="_blank" rel="noopener" aria-label="Marvel Rivals">
-            <img class="icon game-icon" src="assets/icons/marvel-rivals.svg" alt="" aria-hidden="true" />
+            <img class="icon game-icon" src="assets/icons/marvel-rivals.svg" alt="" aria-hidden="true" loading="lazy" />
           </a>
         </div>
 
         <a id="youtube" class="link brand-youtube" href="#" target="_blank" rel="noopener">
-          <img class="icon" src="assets/icons/youtube.svg" alt="" aria-hidden="true" />
+          <img class="icon" src="assets/icons/youtube.svg" alt="" aria-hidden="true" loading="lazy" />
           <span>YouTube</span>
         </a>
       </nav>


### PR DESCRIPTION
## Summary
- add site description meta tag and favicon to `<head>`
- lazy-load all image icons to defer loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b62d1c3830832082a2f07b47807aa9