### PR TITLE
Fix NFO banner import for turbopack

### DIFF
--- a/web/src/components/NfoBanner.tsx
+++ b/web/src/components/NfoBanner.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import art from "@/public/asciart.nfo?raw";
+import { useEffect, useState } from "react";
 
 export default function NfoBanner() {
-  const [text] = useState<string>(art);
+  const [text, setText] = useState<string>("");
+
+  useEffect(() => {
+    fetch("/asciart.nfo")
+      .then((res) => (res.ok ? res.text() : ""))
+      .then((data) => setText(data))
+      .catch(() => setText(""));
+  }, []);
 
   const info = `\n\n   .nfo viewer re: hoppcx.top\n   ───────────────────────────────────────\n   sys: 9800X3D @ 5.7GHZ\n   aim: op1we + obsidian dots @ 50cm on glass pad\n   keys: Fun60proHE + 240hz\n\n   links:\n`;
 

--- a/web/src/types/raw.d.ts
+++ b/web/src/types/raw.d.ts
@@ -1,4 +1,0 @@
-declare module "*.nfo?raw" {
-  const content: string;
-  export default content;
-}


### PR DESCRIPTION
## Summary
- load NFO banner text with `fetch` instead of importing `.nfo` file
- remove obsolete `nfo` raw type definition

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Failed to fetch `JetBrains Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bde9d1ba5483208e3a6e5513921dcf