### PR TITLE
feat: trigger lens capture on ASCII readiness

### DIFF
--- a/web/src/components/LensWarp.tsx
+++ b/web/src/components/LensWarp.tsx
@@ -290,14 +290,15 @@ export default function LensWarp({ k1 = 0.012, k2 = 0.002, center = { x: 0.5, y:
     });
     mo.observe(container, { subtree: true, childList: true, characterData: true, attributes: false });
     window.addEventListener("resize", scheduleCapture);
+    window.addEventListener("ascii-ready", capture);
 
-    // Initial capture & render
-    capture();
+    // Initial capture now triggered via 'ascii-ready' event
 
     return () => {
       ro.disconnect();
       mo.disconnect();
       window.removeEventListener("resize", scheduleCapture);
+      window.removeEventListener("ascii-ready", capture);
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
       if (gl && texRef.current) gl.deleteTexture(texRef.current);
       if (gl && progRef.current) gl.deleteProgram(progRef.current);

--- a/web/src/components/NfoBanner.tsx
+++ b/web/src/components/NfoBanner.tsx
@@ -8,8 +8,14 @@ export default function NfoBanner() {
   useEffect(() => {
     fetch("/asciart.nfo")
       .then((res) => (res.ok ? res.text() : ""))
-      .then((data) => setText(data))
-      .catch(() => setText(""));
+      .then((data) => {
+        setText(data);
+        window.dispatchEvent(new Event("ascii-ready"));
+      })
+      .catch(() => {
+        setText("");
+        window.dispatchEvent(new Event("ascii-ready"));
+      });
   }, []);
 
   const info = `\n\n   .nfo viewer re: hoppcx.top\n   ───────────────────────────────────────\n   sys: 9800X3D @ 5.7GHZ\n   aim: op1we + obsidian dots @ 50cm on glass pad\n   keys: Fun60proHE + 240hz\n\n   links:\n`;


### PR DESCRIPTION
## Summary
- dispatch `ascii-ready` event once NFO text loads
- trigger lens warp capture from `ascii-ready` event
- remove initial capture in favor of event-driven trigger

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68be508d98148320b7d5ed71c034aff6