### PR TITLE
fix: show custom cursor above lens warp

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -270,7 +270,8 @@ body {
   pointer-events: none;
   opacity: 0;
   will-change: transform;
-  z-index: 4; /* above background, below lens warp if any */
+  /* ensure cursor stays visible above lens-warp overlay */
+  z-index: 6;
 }
 
 


### PR DESCRIPTION
## Summary
- ensure CRT cursor stays visible by placing it above the lens-warp canvas

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68c13afeae2c8320a0ee481a7b49f0b9