### PR TITLE
Implement inverse CRT warp mapping and diagnostics

### DIFF
--- a/web/src/components/CRTDevConsole.tsx
+++ b/web/src/components/CRTDevConsole.tsx
@@ -4,7 +4,13 @@
 // Exposes window.CRT with get/set helpers in development builds.
 
 import { useEffect } from "react";
-import { setCRTAlive, setPhosphor } from "@/components/LensWarp";
+import {
+  setCRTAlive,
+  setPhosphor,
+  setCRTWarpSlider,
+  setCRTWarpEnabled,
+  setCRTWarpGrid,
+} from "@/components/LensWarp";
 
 type CRTState = {
   alive: number;
@@ -40,6 +46,10 @@ type CRTApi = {
   mode: (m: 'HQ'|'LQ') => void;
   beam: (opts: { on?: boolean; beamPx?: number; modDepth?: number; interlace?: boolean }) => CRTState;
   debug: (on: boolean, persist?: boolean) => void;
+  warpSlider: (s: number) => CRTState;
+  warpEnabled: (enabled: boolean) => CRTState;
+  warpOff: () => CRTState;
+  warpGrid: (show: boolean) => CRTState;
 };
 
 declare global {
@@ -66,6 +76,10 @@ export default function CRTDevConsole() {
           `window.CRT.phosphor({ rMs,gMs,bMs,halo }) -> set decay (s) and halo gain\n`
           + `window.CRT.mode('HQ'|'LQ')           -> force mode and reload\n`
           + `window.CRT.beam({ on, beamPx, modDepth, interlace }) -> beam controls (HQ only)\n`
+          + `window.CRT.warpSlider(0..1)         -> set warp strength slider\n`
+          + `window.CRT.warpEnabled(true|false)  -> toggle warp on/off\n`
+          + `window.CRT.warpOff()                -> disable warp immediately\n`
+          + `window.CRT.warpGrid(true|false)     -> show sampling grid overlay\n`
           + `window.CRT.debug(true|false[, persist]) -> toggle diagnostic logging\n`
         );
       },
@@ -89,6 +103,10 @@ export default function CRTDevConsole() {
       mode(m: 'HQ'|'LQ') { try { localStorage.setItem('crt-mode', m); } catch {} location.reload(); },
       beam(opts: { on?: boolean; beamPx?: number; modDepth?: number; interlace?: boolean }) { window.dispatchEvent(new CustomEvent('crt-beam', { detail: opts })); return api.get(); },
       debug(on: boolean, persist?: boolean) { window.dispatchEvent(new CustomEvent('crt-debug', { detail: { debug: !!on, persist: !!persist } })); },
+      warpSlider(s: number) { setCRTWarpSlider(s); return api.get(); },
+      warpEnabled(enabled: boolean) { setCRTWarpEnabled(enabled); return api.get(); },
+      warpOff() { setCRTWarpEnabled(false); setCRTWarpSlider(0); return api.get(); },
+      warpGrid(show: boolean) { setCRTWarpGrid(show); return api.get(); },
     };
 
     try {


### PR DESCRIPTION
## Summary
- Implemented warp state helpers with inverse undistort sampling, clamped defaults, slider mapping, and periodic uv diagnostics logging.【F:src/components/LensWarp.tsx†L7-L292】【F:src/components/LensWarp.tsx†L220-L266】
- Rebuilt HQ and fallback fragment shaders to sample via iterative inverse mapping, enforce border guards, and provide a 20×12 debug grid overlay when requested.【F:src/components/LensWarp.tsx†L420-L620】【F:src/components/LensWarp.tsx†L839-L967】
- Matched pointer remapping and event proxy behavior to the shader math, added reentrancy guards, emitted warp state telemetry, and exposed warp/grid controls in the CRT console API.【F:src/components/LensWarp.tsx†L700-L736】【F:src/components/LensWarp.tsx†L1003-L1108】【F:src/components/LensWarp.tsx†L1273-L1485】【F:src/components/CRTDevConsole.tsx†L7-L109】

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68cd61046cd083209ee21417e19437db